### PR TITLE
Add more flexibility on mnemonic imports and defaults to keystore exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eth-keys",
-  "version": "1.1.4",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eth-keys",
-      "version": "1.1.4",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^13.13.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,25 @@
       },
       "bin": {
         "eth-keys": "src/bin/start"
+      },
+      "devDependencies": {
+        "@types/prompts": "^2.4.4"
       }
     },
     "node_modules/@types/node": {
       "version": "13.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
       "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.4.tgz",
+      "integrity": "sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
     },
     "node_modules/aes-js": {
       "version": "3.0.0",
@@ -253,6 +266,16 @@
       "version": "13.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
       "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+    },
+    "@types/prompts": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.4.tgz",
+      "integrity": "sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
     },
     "aes-js": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keys",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Ethereum private key format converter",
   "main": "index.js",
   "repository": "git@github.com:kyledewy/eth-keys.git",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "key",
     "private-key",
     "ethersjs"
-  ]
+  ],
+  "devDependencies": {
+    "@types/prompts": "^2.4.4"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const os_1 = __importDefault(require("os"));
 const ethers_1 = require("ethers");
 const prompts_1 = __importDefault(require("prompts"));
 const privateKeyToWallet = (privKey) => {
@@ -163,7 +165,10 @@ const output = (wallet) => __awaiter(void 0, void 0, void 0, function* () {
         });
         switch (output_format.value) {
             case 1: {
-                const keystore_name = yield textInput('New keystore name: ');
+                const default_keystore_dir = path_1.default.join(os_1.default.homedir(), '.ethereum', 'keystore');
+                const keystore_dir = yield textInput('Keystore directory: ', { initial: default_keystore_dir });
+                const default_geth_filename = `UTC--${new Date().toISOString()}--${wallet.address.slice(2).toLowerCase()}.json`;
+                const keystore_name = yield textInput('New keystore name: ', { initial: default_geth_filename });
                 let keystore_pass = { value: '' };
                 let check = { value: '' };
                 while (check.value !== keystore_pass.value || check.value === '') {
@@ -173,7 +178,7 @@ const output = (wallet) => __awaiter(void 0, void 0, void 0, function* () {
                         console.log('Passwords dont match!');
                     }
                 }
-                const output = `${current_dir}/${keystore_name.value}`;
+                const output = path_1.default.resolve(path_1.default.join(keystore_dir.value, keystore_name.value));
                 yield saveKeystore(wallet, output, keystore_pass.value);
                 return;
             }

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
             }
             case 2: {
                 const mnemonic = yield textInput('Paste the mnemonic: ', { type: 'password' });
-                const path = yield textInput('Paste the mnemonic: ', { initial: "m/44'/60'/0'/0/0" });
+                const path = yield textInput('Choose the derivation path: ', { initial: "m/44'/60'/0'/0/0" });
                 wallet = yield mnemonicToWallet(mnemonic.value, path.value);
                 console.log('[INFO] Opened wallet: ', wallet.address);
                 return wallet;
@@ -154,7 +154,6 @@ const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
 });
 const output = (wallet) => __awaiter(void 0, void 0, void 0, function* () {
     try {
-        const currentDir = process.env.PWD;
         const outputFormat = yield prompts_1.default({
             type: 'select',
             name: 'value',

--- a/src/index.js
+++ b/src/index.js
@@ -55,9 +55,9 @@ const saveKeystore = (wallet, src, pass) => __awaiter(void 0, void 0, void 0, fu
         throw Error(err);
     }
 });
-const decryptKeystore = (keystore_path, password) => __awaiter(void 0, void 0, void 0, function* () {
+const decryptKeystore = (keystorePath, password) => __awaiter(void 0, void 0, void 0, function* () {
     try {
-        const file = fs_1.default.readFileSync(keystore_path);
+        const file = fs_1.default.readFileSync(keystorePath);
         const keystore = JSON.parse(file.toString());
         const wallet = yield ethers_1.ethers.Wallet.fromEncryptedJson(JSON.stringify(keystore), password);
         return wallet;
@@ -91,9 +91,10 @@ const textInput = (message, { type = 'text', initial } = {}) => __awaiter(void 0
     }
 });
 const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
     try {
         let wallet;
-        const key_format = yield prompts_1.default({
+        const keyFormat = yield prompts_1.default({
             type: 'select',
             name: 'value',
             message: 'What format is the private key in?\n',
@@ -104,23 +105,23 @@ const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
                 { title: 'new', value: 4 }
             ]
         });
-        switch (key_format.value) {
+        switch (keyFormat.value) {
             case 1: {
-                let input_keystore = { value: '' };
+                let inputKeystore = { value: '' };
                 let errors = 0;
-                while (!fs_1.default.existsSync(input_keystore.value)) {
-                    if (errors > 3)
+                while (!fs_1.default.existsSync(inputKeystore.value)) {
+                    if (errors > 3) {
                         throw Error('Failed to find keystore file');
-                    input_keystore = yield textInput(`Keystore file: \n ${process.env.PWD}/<keystore_file>`);
-                    // TODO: check for absolute paths
-                    input_keystore.value = process.env.PWD + '/' + input_keystore.value;
-                    if (!fs_1.default.existsSync(input_keystore.value)) {
-                        console.log(`File doesn't exist ${input_keystore.value}`);
+                    }
+                    inputKeystore = yield textInput(`Keystore file: \n ${process.env.PWD}/<keystore_file>`);
+                    inputKeystore.value = path_1.default.resolve((_a = process.env.PWD) !== null && _a !== void 0 ? _a : '', inputKeystore.value);
+                    if (!fs_1.default.existsSync(inputKeystore.value)) {
+                        console.log(`File doesn't exist ${inputKeystore.value}`);
                         errors++;
                     }
                 }
-                const old_keystore_pass = yield textInput('Password to decrypt keystore: ', { type: 'password' });
-                wallet = yield decryptKeystore(input_keystore.value, old_keystore_pass.value);
+                const oldKeystorePass = yield textInput('Password to decrypt keystore: ', { type: 'password' });
+                wallet = yield decryptKeystore(inputKeystore.value, oldKeystorePass.value);
                 console.log('[INFO] Decrypted wallet: ', wallet.address);
                 return wallet;
             }
@@ -132,8 +133,8 @@ const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
                 return wallet;
             }
             case 3: {
-                const private_key = yield textInput('Paste the private key: ', { type: 'password' });
-                wallet = yield privateKeyToWallet(private_key.value);
+                const privateKey = yield textInput('Paste the private key: ', { type: 'password' });
+                wallet = yield privateKeyToWallet(privateKey.value);
                 console.log('[INFO] Opened wallet: ', wallet.address);
                 return wallet;
             }
@@ -153,8 +154,8 @@ const getWallet = () => __awaiter(void 0, void 0, void 0, function* () {
 });
 const output = (wallet) => __awaiter(void 0, void 0, void 0, function* () {
     try {
-        const current_dir = process.env.PWD;
-        const output_format = yield prompts_1.default({
+        const currentDir = process.env.PWD;
+        const outputFormat = yield prompts_1.default({
             type: 'select',
             name: 'value',
             message: 'What format to output?\n',
@@ -163,23 +164,23 @@ const output = (wallet) => __awaiter(void 0, void 0, void 0, function* () {
                 { title: 'private key', value: 2 }
             ]
         });
-        switch (output_format.value) {
+        switch (outputFormat.value) {
             case 1: {
-                const default_keystore_dir = path_1.default.join(os_1.default.homedir(), '.ethereum', 'keystore');
-                const keystore_dir = yield textInput('Keystore directory: ', { initial: default_keystore_dir });
-                const default_geth_filename = `UTC--${new Date().toISOString()}--${wallet.address.slice(2).toLowerCase()}.json`;
-                const keystore_name = yield textInput('New keystore name: ', { initial: default_geth_filename });
-                let keystore_pass = { value: '' };
+                const defaultKeystoreDir = path_1.default.join(os_1.default.homedir(), '.ethereum', 'keystore');
+                const keystoreDir = yield textInput('Keystore directory: ', { initial: defaultKeystoreDir });
+                const defaultGethFilename = `UTC--${new Date().toISOString()}--${wallet.address.slice(2).toLowerCase()}.json`;
+                const keystoreName = yield textInput('New keystore name: ', { initial: defaultGethFilename });
+                let keystorePass = { value: '' };
                 let check = { value: '' };
-                while (check.value !== keystore_pass.value || check.value === '') {
-                    keystore_pass = yield textInput('New password for keystore: ', { type: 'password' });
+                while (check.value !== keystorePass.value || check.value === '') {
+                    keystorePass = yield textInput('New password for keystore: ', { type: 'password' });
                     check = yield textInput('Repeat password for keystore: ', { type: 'password' });
-                    if (keystore_pass.value !== check.value) {
+                    if (keystorePass.value !== check.value) {
                         console.log('Passwords dont match!');
                     }
                 }
-                const output = path_1.default.resolve(path_1.default.join(keystore_dir.value, keystore_name.value));
-                yield saveKeystore(wallet, output, keystore_pass.value);
+                const output = path_1.default.resolve(keystoreDir.value, keystoreName.value);
+                yield saveKeystore(wallet, output, keystorePass.value);
                 return;
             }
             case 2: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import fs from 'fs'
+import path from 'path'
+import os from 'os'
 import { ethers } from 'ethers'
 import prompts from 'prompts'
 
@@ -168,9 +170,15 @@ const output = async (wallet: any) => {
     })
     switch (output_format.value) {
       case 1: {
-        const keystore_name = await textInput('New keystore name: ')
+        const default_keystore_dir = path.join(os.homedir(), '.ethereum', 'keystore')
+        const keystore_dir = await textInput('Keystore directory: ', { initial: default_keystore_dir })
+
+        const default_geth_filename = `UTC--${new Date().toISOString()}--${wallet.address.slice(2).toLowerCase()}.json`
+        const keystore_name = await textInput('New keystore name: ', { initial: default_geth_filename })
+
         let keystore_pass = { value: '' }
         let check = { value: '' }
+
         while (check.value !== keystore_pass.value || check.value === '') {
           keystore_pass = await textInput(
             'New password for keystore: ',
@@ -181,9 +189,10 @@ const output = async (wallet: any) => {
             console.log('Passwords dont match!')
           }
         }
-        const output = `${current_dir}/${keystore_name.value}`
+        const output = path.resolve(path.join(keystore_dir.value, keystore_name.value))
         await saveKeystore(wallet, output, keystore_pass.value)
         return
+
       }
       case 2: {
         console.log(wallet.privateKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ const getWallet = async () => {
       }
       case 2: {
         const mnemonic = await textInput('Paste the mnemonic: ', { type: 'password' })
-        const path = await textInput('Paste the mnemonic: ', { initial: "m/44'/60'/0'/0/0" })
+        const path = await textInput('Choose the derivation path: ', { initial: "m/44'/60'/0'/0/0" })
         wallet = await mnemonicToWallet(mnemonic.value, path.value)
         console.log('[INFO] Opened wallet: ', wallet.address)
         return wallet


### PR DESCRIPTION
My main use case for this package is when I need to export one of my hot wallets to a keystore file.

As it is right now, the import from mnemonic phrases does not allow the user to specify the derivation path, so it ends up importing only the account in `m/44'/60'/0'/0/0`, which is the 1st one.

Another slightly annoying issue is that some tools which support keystore files adopt the Geth directory and file naming by default. I added these as the default value for the keystore format export.